### PR TITLE
Fix issue #67

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@types/temp": "^0.9.0",
     "lookpath": "^1.2.0",
+    "js-base64": "^3.7.2",
     "temp": "^0.9.4",
     "yaml": "^2.0.0-4"
   }

--- a/renderer.ts
+++ b/renderer.ts
@@ -10,6 +10,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as YAML from 'yaml';
+import { Base64 } from 'js-base64';
 
 import { FileSystemAdapter, MarkdownRenderer, MarkdownView, Notice } from 'obsidian';
 
@@ -267,7 +268,7 @@ function convertSVGToPNG(svg: SVGSVGElement, scale: number = 1): Promise<HTMLIma
     canvas.height = Math.ceil(svg.height.baseVal.value * scale);
     const ctx = canvas.getContext('2d');
     var svgImg = new Image;
-    svgImg.src = "data:image/svg+xml;base64," + btoa(svg.outerHTML);
+    svgImg.src = "data:image/svg+xml;base64," + Base64.encode(svg.outerHTML);
     return new Promise((resolve, reject) => {
         svgImg.onload = () => {
             ctx.drawImage(svgImg, 0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
FIx #67
replace btoa to js-base64 encode in convertSVGtoPNG() in renderer.ts
because btoa() on a SVG data that contains non-Latin1 characters get InvalidCharacterError