### PR TITLE
Allow spaces in paths in Extra Pandoc arguments

### DIFF
--- a/pandoc.ts
+++ b/pandoc.ts
@@ -139,7 +139,7 @@ export const pandoc = async (input: PandocInput, output: PandocOutput, extraPara
     if (input.metadataFile) args.push('--metadata-file', input.metadataFile);
     // Extra parameters
     if (extraParams) {
-        extraParams = extraParams.flatMap(x => x.split(' ')).filter(x => x.length);
+        extraParams = extraParams.flatMap(x => x).filter(x => x.length);
         args.push(...extraParams);
     }
 


### PR DESCRIPTION
Fixes #77 
Fixes #86 
Fixes #113 
Fixes #136 
Fixes #159 
using the [fix suggested by GittyBruce](https://github.com/OliverBalfour/obsidian-pandoc/issues/159#issuecomment-1530833336).

Filepaths with spaces can now be specified in the Extra Pandoc arguments using the following form (no quote marks or backslash escapes), using the defaults option as an example: 
```
--defaults=/file path/with spaces/defaults.yaml
```