### PR TITLE
add the relative path and fix some problem

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - [@OliverBalfour](https://github.com/OliverBalfour)
 - Jan Losinski ([@janLo](https://github.com/janLo))
 - Phillip Johnston ([@phillipjohnston](https://github.com/phillipjohnston))
+- Wanstarge ([@wanstarge](<https://github.com/phillipjohnston>))

--- a/README-CN.md
+++ b/README-CN.md
@@ -1,0 +1,32 @@
+## Obsidian Pandoc Plugin
+[English](README.md)
+
+这是一个为[Obsidian](https://obsidian.md)设计的 Pandoc 导出插件。 .
+
+它为 Obsidian 的命令面板添加了导出选项，可以将你的笔记导出为多种格式，包括 Word 文档、PDF 文件、ePub 电子书、HTML 网站、PowerPoint 幻灯片和 LaTeX 等（还有很多其他格式）。这一切都归功于[Pandoc](https://pandoc.org/).
+
+通过这个插件，你可以在 Markdown 中编写演示文稿、草拟书籍、制作网页以及编写作业，并且可以导出为你喜欢的任何格式，所有这些操作都可以在 Obsidian 中完成。
+
+>注意：这个插件目前处于测试阶段，可能会有一些格式问题。请务必检查导出后的文件！
+
+![screenshot of command palette](./command-palette.png)
+
+## [安装](https://github.com/OliverBalfour/obsidian-pandoc/wiki/Installation)
+
+安装说明在维基页面上，可以通过上面的链接查看。
+
+参与开发的设置说明在[development.md](./development.md)文件中
+
+## 基本使用
+- 按下 Ctrl+P 或 Cmd+P 打开命令面板。
+- 搜索“Pandoc”。
+- 选择你需要的导出格式。
+- 如果一切顺利，它会显示导出成功。
+- 如果你将一个名为 Pandoc.md 的文件导出为 Word 文档，那么在你的文件浏览器中，你会在同一个文件夹下找到一个名为 Pandoc.docx 的文件。
+
+## Documentation
+* [Using Pandoc templates](https://github.com/OliverBalfour/obsidian-pandoc/wiki/Pandoc-Templates)
+* [Using Pandoc citations](https://github.com/OliverBalfour/obsidian-pandoc/wiki/Citations-(work-in-progress))
+* [Combining/concatenating documents](https://github.com/OliverBalfour/obsidian-pandoc/wiki/Combining-Documents)
+* [Troubleshooting](https://github.com/OliverBalfour/obsidian-pandoc/wiki/Troubleshooting)
+* [Installation](https://github.com/OliverBalfour/obsidian-pandoc/wiki/Installation)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Obsidian Pandoc Plugin
 
+[中文](README-CN.md)
+
 This is a Pandoc export plugin for Obsidian (https://obsidian.md).
 
 It adds command palette options to export your notes to a variety of formats including Word Documents, PDFs, ePub books, HTML websites, PowerPoints and LaTeX among (many) others. This is all thanks to [Pandoc](https://pandoc.org/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-pandoc-plugin",
-  "version": "0.3.0",
+  "version": "0.1.0",
   "description": "Document exporting plugin for Obsidian using Pandoc",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
This modification allows users to use relative paths relative to the vault library in the extra args, and improves the function of exporting wiki image links when Markdown is used as the source format.

And I also add the chinese README